### PR TITLE
fix: replace deprecated import [BB-4724]

### DIFF
--- a/edx_oauth_client/pipeline.py
+++ b/edx_oauth_client/pipeline.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.template.defaultfilters import slugify
 from openedx.core.djangoapps.user_authn.views.registration_form import AccountCreationForm
 from social_core.pipeline import partial
-from student.helpers import do_create_account
+from common.djangoapps.student.helpers import do_create_account
 
 log = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='edx-oauth-client',
-    version='2.0.0',
+    version='2.0.1',
     description='Client OAuth2 from edX installations',
     author='edX',
     url='https://github.com/raccoongang/edx_oauth_client',


### PR DESCRIPTION
These paths were deprecated in Lilac:
https://github.com/edx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst