### PR TITLE
fix: add `v1` to `API_URLS`

### DIFF
--- a/edx_oauth_client/constants.py
+++ b/edx_oauth_client/constants.py
@@ -7,6 +7,7 @@ OAUTH_PROCESS_URLS = ("oauth2", "auth", "login_oauth_token", "social-logout")
 API_URLS = (
     "certificates",
     "api",
+    "v1",
     "user_api",
     "notifier_api",
     "update_example_certificate",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='edx-oauth-client',
-    version='2.1.0',
+    version='2.1.1',
     description='Client OAuth2 from edX installations',
     author='edX',
     url='https://github.com/raccoongang/edx_oauth_client',


### PR DESCRIPTION
This unusual pattern is used by the `BulkUsersRetirementView`: https://github.com/openedx/edx-platform/blob/154cc8141d36fc971f2cf73a40171cb9a80b14ca/lms/djangoapps/bulk_user_retirement/views.py#L27-L27

## Other information
Private-ref: [BB-6662](https://tasks.opencraft.com/browse/BB-6662)