### PR TITLE
feat: make the seamless authorization backend configurable [BB-7052]

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,5 @@ Redirect uri must be **http://<edx_url>/auth/complete/custom-oauth2/**
    ```
    EXTRA_MIDDLEWARE_CLASSES: ["edx_oauth_client.middleware.seamless_authorization",]
    ```
-   
-   This feature requires to update you provider site's behaviour:
-
-   Create multi-domain cookies named `authenticated=1` and `authenticated_user=<username>` if user is logged in. And delete these cookies on logout
-   
-   Also you should initiate user creation on edX after user creation on Provider. You need to send GET request to Edx API on url:
-   ```
-   https://<edx-url>/auth/complete/edx-oauth2/?state=<state>&code=<code>
-   ```
-   
-   Where `state` is md5(time()) and `code` is code for authorization (create it if doesn't exist)
- 
-**Note.** If you work on local devstack. Inside your edx’s vagrant in /etc/hosts add a row with your machine’s IP  and drupal’s vhost. For example:
-```192.168.0.197 sso.local```
+ - If you want to configure a backend (other than GenericOAuthBackend) used by the seamless authorization,
+   set its name as the `SEAMLESS_AUTHORIZATION_BACKEND` variable in your settings.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ Redirect uri must be **http://<edx_url>/auth/complete/custom-oauth2/**
    ```
  - If you want to configure a backend (other than GenericOAuthBackend) used by the seamless authorization,
    set its name as the `SEAMLESS_AUTHORIZATION_BACKEND` variable in your settings.
+ - If you want to use the seamless authorization only when a specific cookie is passed with the request,
+   set its name as the `SEAMLESS_AUTHORIZATION_CHECK_COOKIE` variable in your settings.

--- a/edx_oauth_client/constants.py
+++ b/edx_oauth_client/constants.py
@@ -3,7 +3,7 @@ Constants for the operation of the module.
 Keep immutable values here so as not to clog the namespace of OAuth backend and middleware layer.
 """
 
-OAUTH_PROCESS_URLS = ("oauth2", "auth", "login_oauth_token", "social-logout")
+OAUTH_PROCESS_URLS = ("oauth2", "auth", "login_oauth_token", "social-logout", "login_refresh")
 API_URLS = (
     "certificates",
     "api",

--- a/edx_oauth_client/middleware.py
+++ b/edx_oauth_client/middleware.py
@@ -24,7 +24,7 @@ except ImportError:
 
 def seamless_authorization(get_response: Callable[[HttpRequest], HttpResponse]):
     """A middleware for force authenticating users."""
-    backend = GenericOAuthBackend.name
+    backend = getattr(settings, 'SEAMLESS_AUTHORIZATION_BACKEND', GenericOAuthBackend.name)
 
     def ignore_url(request: HttpRequest) -> bool:
         """Determine whether the request should bypass the forced authentication."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django<3.3
-social-auth-core<4.0.0
+social-auth-core
 social-auth-app-django

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='edx-oauth-client',
-    version='2.1.1',
+    version='2.2.0',
     description='Client OAuth2 from edX installations',
     author='edX',
     url='https://github.com/raccoongang/edx_oauth_client',


### PR DESCRIPTION
This allows customizing a backend used by the seamless authorization.

It also unpins `social-auth-core`, as it does not introduce breaking changes for this repository.