### PR TITLE
chore: add Sumac URLs to the allowed ones

### DIFF
--- a/edx_oauth_client/constants.py
+++ b/edx_oauth_client/constants.py
@@ -15,6 +15,7 @@ API_URLS = (
     "request_certificate",
     "heartbeat",
     "admin",
+    "assets",
 )
 
 LOCAL_URLS = (

--- a/edx_oauth_client/middleware.py
+++ b/edx_oauth_client/middleware.py
@@ -32,7 +32,7 @@ def seamless_authorization(get_response: Callable[[HttpRequest], HttpResponse]):
         ignored_urls = OAUTH_PROCESS_URLS + API_URLS
         if settings.DEBUG:
             ignored_urls += LOCAL_URLS
-        return start_url_path in ignored_urls
+        return start_url_path in ignored_urls or start_url_path.startswith("asset-v1:")
 
     def has_cookie(request: HttpRequest) -> bool:
         """

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='edx-oauth-client',
-    version='2.2.0',
+    version='2.2.1',
     description='Client OAuth2 from edX installations',
     author='edX',
     url='https://github.com/raccoongang/edx_oauth_client',


### PR DESCRIPTION
The assets middleware was changed in Sumac. We do not want to gate publicly available assets (such as course images) behind the forced SSO.